### PR TITLE
Update mappings to use entity types generated from the subgraph schema

### DIFF
--- a/mappings/collateralizer.ts
+++ b/mappings/collateralizer.ts
@@ -2,40 +2,47 @@
 import 'allocator/arena'
 export { allocate_memory }
 
-// Import types and APIs from graph-ts
-import { Entity, store } from '@graphprotocol/graph-ts'
+// Import APIs from graph-ts
+import { store } from '@graphprotocol/graph-ts'
 
 // Import event types from the registrar contract ABI
-import { CollateralLocked, CollateralReturned, CollateralSeized } from '../types/Collateralizer/Collateralizer'
+import {
+  CollateralLocked,
+  CollateralReturned,
+  CollateralSeized,
+} from '../types/Collateralizer/Collateralizer'
+
+// Import entity types from the schema
+import { Collateral } from '../types/schema'
 
 export function handleLock(event: CollateralLocked): void {
-  let collateral = new Entity()
   let id = event.params.agreementID.toHex()
 
-  collateral.setString('id', id)
-  collateral.setAddress('tokenAddress', event.params.token)
-  collateral.setU256('amount', event.params.amount)
-  collateral.setString('status', "locked")
-  collateral.setString('debtOrder', id)
+  let collateral = new Collateral()
+  collateral.tokenAddress = event.params.token
+  collateral.amount = event.params.amount
+  collateral.status = 'locked'
+  collateral.debtOrder = id
 
   store.set('Collateral', id, collateral)
 }
 
 export function handleReturned(event: CollateralReturned): void {
-  let returning = new Entity()
   let id = event.params.agreementID.toHex()
 
-  returning.setAddress('collateralReturnedTo', event.params.collateralizer)
-  returning.setString('status', "returned")
+  let collateral = new Collateral()
+  collateral.collateralReturnedTo = event.params.collateralizer
+  collateral.status = 'returned'
 
-  store.set('Collateral', id, returning)
+  store.set('Collateral', id, collateral)
 }
 
 export function handleSeized(event: CollateralSeized): void {
-  let seizing = new Entity()
   let id = event.params.agreementID.toHex()
 
-  seizing.setAddress('collateralReturnedTo', event.params.beneficiary)
-  seizing.setString('status', "seized")
-  store.set('Collateral', id, seizing)
+  let collateral = new Collateral()
+  collateral.collateralReturnedTo = event.params.beneficiary
+  collateral.status = 'seized'
+
+  store.set('Collateral', id, collateral)
 }

--- a/mappings/debt-kernel.ts
+++ b/mappings/debt-kernel.ts
@@ -2,47 +2,50 @@
 import 'allocator/arena'
 export { allocate_memory }
 
-// Import types and APIs from graph-ts
-import { Entity, store, Value } from '@graphprotocol/graph-ts'
+// Import APIs from graph-ts
+import { store } from '@graphprotocol/graph-ts'
 
 // Import event types from the registrar contract ABI
-import { LogDebtOrderFilled, LogIssuanceCancelled, LogDebtOrderCancelled } from '../types/DebtKernel/DebtKernel'
+import {
+  LogDebtOrderFilled,
+  LogIssuanceCancelled,
+  LogDebtOrderCancelled,
+} from '../types/DebtKernel/DebtKernel'
+
+// Import entity types from the schema
+import { CancelledDebtOrder, DebtOrder } from '../types/schema'
 
 export function handleDebtOrderFilled(event: LogDebtOrderFilled): void {
-    let debtOrder = new Entity()
+  let id = event.params._agreementId.toHex()
 
-    let id = event.params._agreementId.toHex()
-
-    debtOrder.setString('id', id)
-    debtOrder.setU256('principle', event.params._principal)
-    debtOrder.setAddress('principleToken', event.params._principalToken)
-    debtOrder.setAddress('underwriter', event.params._underwriter)
-    debtOrder.setU256('underwriterFee', event.params._underwriterFee)
-    debtOrder.setAddress('relayer', event.params._relayer)
-    debtOrder.setU256('relayerFee', event.params._relayerFee)
-    debtOrder.setArray('collaterals', new Array<Value>())
-    debtOrder.setArray('repayments', new Array<Value>())
-
+  let debtOrder = new DebtOrder()
+  debtOrder.principle = event.params._principal
+  debtOrder.principleToken = event.params._principalToken
+  debtOrder.underwriter = event.params._underwriter
+  debtOrder.underwriterFee = event.params._underwriterFee
+  debtOrder.relayer = event.params._relayer
+  debtOrder.relayerFee = event.params._relayerFee
+  debtOrder.collaterals = []
+  debtOrder.repayments = []
 
   store.set('DebtOrder', id, debtOrder)
 }
 
 // This event has never actually been called on mainnet or kovan, so it is returning blank queries
 export function handleIssuanceCancelled(event: LogIssuanceCancelled): void {
-    let id = event.params._agreementId.toHex()
-    let debtOrder  = new Entity()
+  let id = event.params._agreementId.toHex()
 
-    debtOrder.setAddress('issuanceCancelledBy', event.params._cancelledBy)
-    store.set('DebtOrder', id, debtOrder)
+  let debtOrder = new DebtOrder()
+  debtOrder.issuanceCancelledBy = event.params._cancelledBy
 
+  store.set('DebtOrder', id, debtOrder)
 }
 
 export function handleDebtCancelled(event: LogDebtOrderCancelled): void {
-    let cancelledDebt = new Entity()
-    let id = event.params._debtOrderHash.toHex()
+  let id = event.params._debtOrderHash.toHex()
 
-    cancelledDebt.setString('id', id)
-    cancelledDebt.setAddress('cancelledBy', event.params._cancelledBy)
+  let cancelledDebt = new CancelledDebtOrder()
+  cancelledDebt.cancelledBy = event.params._cancelledBy
 
-    store.set('CancelledDebtOrder', id, cancelledDebt)
+  store.set('CancelledDebtOrder', id, cancelledDebt)
 }

--- a/mappings/debt-registry.ts
+++ b/mappings/debt-registry.ts
@@ -2,30 +2,36 @@
 import 'allocator/arena'
 export { allocate_memory }
 
-// Import types and APIs from graph-ts
-import { Entity, store } from '@graphprotocol/graph-ts'
+// Import APIs from graph-ts
+import { store } from '@graphprotocol/graph-ts'
 
 // Import event types from the registrar contract ABI
-import { LogInsertEntry, LogModifyEntryBeneficiary } from '../types/DebtRegistry/DebtRegistry'
+import {
+  LogInsertEntry,
+  LogModifyEntryBeneficiary,
+} from '../types/DebtRegistry/DebtRegistry'
+
+// Import entity types from the schema
+import { DebtOrder } from '../types/schema'
 
 export function handleLogInsertEntry(event: LogInsertEntry): void {
-    let entry = new Entity()
-    let id = event.params.agreementId.toHex()
+  let id = event.params.agreementId.toHex()
 
-    entry.setString('id', id)
-    entry.setAddress('beneficiary', event.params.beneficiary)
-    entry.setAddress('underwriter', event.params.underwriter)
-    entry.setU256('underwriterRiskRating', event.params.underwriterRiskRating)
-    entry.setAddress('termsContract', event.params.termsContract)
-    entry.setBytes('termsContractParameters', event.params.termsContractParameters)
+  let debtOrder = new DebtOrder()
+  debtOrder.beneficiary = event.params.beneficiary
+  debtOrder.underwriter = event.params.underwriter
+  debtOrder.underwriterRiskRating = event.params.underwriterRiskRating
+  debtOrder.termsContract = event.params.termsContract
+  debtOrder.termsContractParameters = event.params.termsContractParameters
 
-    store.set('DebtOrder', id, entry)
+  store.set('DebtOrder', id, debtOrder)
 }
 
 export function handleModifyBeneficiary(event: LogModifyEntryBeneficiary): void {
-    let id = event.params.agreementId.toHex()
-    let regDebt = new Entity()
+  let id = event.params.agreementId.toHex()
 
-    regDebt.setAddress('beneficiary', event.params.newBeneficiary)
-    store.set('DebtOrder', id, regDebt)
+  let debtOrder = new DebtOrder()
+  debtOrder.beneficiary = event.params.newBeneficiary
+
+  store.set('DebtOrder', id, debtOrder)
 }

--- a/mappings/repayment-router.ts
+++ b/mappings/repayment-router.ts
@@ -2,53 +2,55 @@
 import 'allocator/arena'
 export { allocate_memory }
 
-// Import types and APIs from graph-ts
-import { Entity, store, Value } from '@graphprotocol/graph-ts'
+// Import APIs from graph-ts
+import { store } from '@graphprotocol/graph-ts'
 
 // Import event types from the registrar contract ABI
 import { LogRepayment } from '../types/RepaymentRouter/RepaymentRouter'
 
+// Import entity types from the schema
+import { Repayment } from '../types/schema'
+
 export function handleRepayment(event: LogRepayment): void {
   let id = event.params._agreementId.toHex()
 
-  let repayment = store.get('Repayment', id)
+  let repayment = store.get('Repayment', id) as Repayment | null
 
   if (repayment == null) {
-    repayment = new Entity()
-    repayment.setArray('payers', new Array<Value>())
-    repayment.setArray('beneficiaries', new Array<Value>())
-    repayment.setArray('amounts', new Array<Value>())
-    repayment.setString('debtOrder', id)
-    // repayment.setU256('amountRepaid', event.params._amount)
+    repayment = new Repayment()
+    repayment.payers = []
+    repayment.beneficiaries = []
+    repayment.amounts = []
+    repayment.debtOrder = id
+    // repayment.amountRepaid = event.params._amount
   }
 
-  let payers = repayment.getArray('payers')
-  let beneficiaries = repayment.getArray('beneficiaries')
-  let amounts = repayment.getArray('amounts')
+  let payers = repayment.payers
+  let beneficiaries = repayment.beneficiaries
+  let amounts = repayment.amounts
 
-  payers.push(Value.fromAddress(event.params._payer))
-  beneficiaries.push(Value.fromAddress(event.params._beneficiary))
-  amounts.push(Value.fromU256(event.params._amount))
+  payers.push(event.params._payer)
+  beneficiaries.push(event.params._beneficiary)
+  amounts.push(event.params._amount)
 
   // dont have to set again when fixed
-  // repayment.setArray('payer', payers)
-  // repayment.setArray('beneficiary', beneficiaries)
-  // repayment.setArray('amount', amounts)
+  // repayment.payers payers
+  // repayment.beneficiarys beneficiaries
+  // repayment.amounts, amounts
 
-  store.set('Repayment', id, repayment as Entity)
+  store.set('Repayment', id, repayment as Repayment)
 }
 
 // So that we don't add twice on the first try
 // if (repayment != null) {
-//   let previousPaid = repayment.getU256('amountRepaid')
+//   let previousPaid = repayment.amountRepaid
 //   let combined = addition(event.params._amount, previousPaid)
-//   repayment.setU256('amountRepaid', combined)
+//   repayment.amountRepaid = combined
 // }
 
-// function addition(a: U256, b: U256): U256 {
+// function addition(a: BigInt, b: BigInt): BigInt {
 //   let first = Number(a)
 //   let second = Number(b)
 //   let total = first + second
-//   let final = <U256>(total)
-//   return total as U256
+//   return total as BigInt
 // }

--- a/mappings/repayment-router.ts
+++ b/mappings/repayment-router.ts
@@ -34,9 +34,9 @@ export function handleRepayment(event: LogRepayment): void {
   amounts.push(event.params._amount)
 
   // dont have to set again when fixed
-  // repayment.payers payers
-  // repayment.beneficiarys beneficiaries
-  // repayment.amounts, amounts
+  repayment.payers = payers
+  repayment.beneficiaries = beneficiaries
+  repayment.amounts = amounts
 
   store.set('Repayment', id, repayment as Repayment)
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
     "codegen": "graph codegen --output-dir types/ subgraph.yaml",
     "build": "graph build subgraph.yaml",
     "build-ipfs": "graph build --ipfs /ip4/127.0.0.1/tcp/5001 subgraph.yaml",
-    "deploy":
-    "graph deploy --ipfs /ip4/127.0.0.1/tcp/5001 --node http://127.0.0.1 --subgraph-name dharma subgraph.yaml"
+    "deploy": "graph deploy --ipfs /ip4/127.0.0.1/tcp/5001 --node http://127.0.0.1 --subgraph-name dharma subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "^0.3.2",
-    "@graphprotocol/graph-ts": "^0.3.4"
+    "@graphprotocol/graph-cli": "^0.4.0",
+    "@graphprotocol/graph-ts": "^0.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,22 +2,24 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-cli@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.3.2.tgz#95be1baa8e7f27d261420b94d309c531722c66c2"
-  integrity sha512-kgVQUVQo1rnODEdBxyyzd8/TgXeLo9QcPAgeA+DLz4bT13pn4yLQ3q1XbzyjHie1KnHJ1NlBXiBNrXuzSrmS9A==
+"@graphprotocol/graph-cli@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.4.0.tgz#9f5201d211ceea588d964cb202cc103a74f29355"
+  integrity sha512-Mgi95Bi2bpjHjtPObe4XRjV80j+s6gWUixtqmHjwdGZgd44O1OxvZPTdYODCqhOb/wIGUvMZ8N/Ml26TO+iX2w==
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#c4ebc8c291c1068da73ddf1a381eab93e1f69e11"
     chalk "^2.4.1"
     chokidar "^2.0.4"
-    commander "^2.15.1"
+    commander "^2.18.0"
     debug "^3.1.0"
     fs-extra "^6.0.1"
     glob "^7.1.2"
+    graphql "^14.0.2"
     immutable "^3.8.2"
     ipfs-api "^22.2.1"
     jayson "^2.0.6"
     js-yaml "^3.12.0"
+    pkginfo "^0.4.1"
     prettier "^1.13.5"
     request "^2.88.0"
     winston "^3.0.0"
@@ -28,6 +30,13 @@
   integrity sha512-x8W/TP22TLOyl5uD1v5nSUedgEIwzrQoEINZmhy12zxT2EZM/1hj/+v0FYgevCv3lvnw2wI8R3tJMNrvUF2Hkg==
   dependencies:
     assemblyscript "^0.3.0"
+
+"@graphprotocol/graph-ts@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.4.0.tgz#4327b25dd6cfa7c484debdffc48c0844ad6b5d24"
+  integrity sha512-xxXZzm6a6kxDlXPNjD+6CbOWjNluj79iIvgCqDrgUBvlByL3iybXyLyWVCh24/G9nQ5PNqJe1oD4R8T+aLl9iw==
+  dependencies:
+    assemblyscript "https://github.com/AssemblyScript/assemblyscript#c4ebc8c291c1068da73ddf1a381eab93e1f69e11"
 
 "@protobufjs/utf8@^1.1.0":
   version "1.1.0"
@@ -157,6 +166,15 @@ assemblyscript@^0.3.0:
     chalk "^2.1.0"
     minimist "^1.2.0"
     wabt "0.0.13-nightly.20170628"
+
+"assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#c4ebc8c291c1068da73ddf1a381eab93e1f69e11":
+  version "0.5.0"
+  uid c4ebc8c291c1068da73ddf1a381eab93e1f69e11
+  resolved "git+https://github.com/AssemblyScript/assemblyscript.git#c4ebc8c291c1068da73ddf1a381eab93e1f69e11"
+  dependencies:
+    "@protobufjs/utf8" "^1.1.0"
+    binaryen "48.0.0-nightly.20180627"
+    long "^4.0.0"
 
 "assemblyscript@https://github.com/AssemblyScript/assemblyscript#c4ebc8c291c1068da73ddf1a381eab93e1f69e11":
   version "0.5.0"
@@ -558,10 +576,15 @@ commander@^2.12.2:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
   integrity sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==
 
-commander@^2.15.0, commander@^2.15.1:
+commander@^2.15.0:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
+
+commander@^2.18.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -995,6 +1018,13 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
+graphql@^14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.2.tgz#7dded337a4c3fd2d075692323384034b357f5650"
+  integrity sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==
+  dependencies:
+    iterall "^1.2.2"
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -1412,6 +1442,11 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+iterall@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
+  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 jayson@^2.0.6:
   version "2.0.6"
@@ -2118,6 +2153,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+pkginfo@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
+  integrity sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
This updates the Dharma subgraph to the latest graph-cli and graph-ts releases, allowing it to use entity types generated from the GraphQL schema.

Note: This is a mandatory update to keep the subgraph working once https://github.com/graphprotocol/graph-node/pull/541 is merged.

Tested against mainnet.